### PR TITLE
Fix Swift CocoaPods integration

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		4A22F3A632821E692970E60982DCF798 /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F60C2A25E763FDD014FF3FD5A14CB784 /* CoreMotion.framework */; };
 		4AD7359493D5E26709639CCFA125CFC9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02EAB039633786826B1E43CD3480CEE5 /* UIKit.framework */; };
 		4EBC8DFE23C6C29F7AC3734BA8B2080B /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1B396E078D78305E512F388B9C9B275 /* SystemConfiguration.framework */; };
+		88A58AC31D99244B005CD072 /* PodsDummy_PredictIO.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A58AC21D99244B005CD072 /* PodsDummy_PredictIO.m */; };
+		88A58AC41D99244B005CD072 /* PodsDummy_PredictIO.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A58AC21D99244B005CD072 /* PodsDummy_PredictIO.m */; };
 		88AF86121D90322D00398387 /* libPredictIO.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 88AF86111D90322D00398387 /* libPredictIO.a */; };
 		88AF86131D90322D00398387 /* libPredictIO.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 88AF86111D90322D00398387 /* libPredictIO.a */; };
 		88AF86431D903D5500398387 /* PIOTripSegment.h in Headers */ = {isa = PBXBuildFile; fileRef = 88AF86411D903D5500398387 /* PIOTripSegment.h */; };
@@ -56,6 +58,7 @@
 		7B8AA98CAA6A0CCE1556C2738EC51ADC /* PredictIO.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PredictIO.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		80E5E321FD4B666FCF0DF7970CA7FF51 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		82F0DE8E21B363FF4A999C4D37534578 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk/System/Library/Frameworks/CoreBluetooth.framework; sourceTree = DEVELOPER_DIR; };
+		88A58AC21D99244B005CD072 /* PodsDummy_PredictIO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PodsDummy_PredictIO.m; sourceTree = "<group>"; };
 		88AF86111D90322D00398387 /* libPredictIO.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libPredictIO.a; sourceTree = "<group>"; };
 		88AF86411D903D5500398387 /* PIOTripSegment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PIOTripSegment.h; sourceTree = "<group>"; };
 		88AF86421D903D5500398387 /* PredictIO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PredictIO.h; sourceTree = "<group>"; };
@@ -179,6 +182,7 @@
 			children = (
 				88AF86411D903D5500398387 /* PIOTripSegment.h */,
 				88AF86421D903D5500398387 /* PredictIO.h */,
+				88A58AC21D99244B005CD072 /* PodsDummy_PredictIO.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -320,6 +324,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88A58AC41D99244B005CD072 /* PodsDummy_PredictIO.m in Sources */,
 				CD7CCF0E098B032961059943EECA355B /* PredictIO-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -328,6 +333,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88A58AC31D99244B005CD072 /* PodsDummy_PredictIO.m in Sources */,
 				AC7520A21CF4CBF95A9806F104037F70 /* Pods-PredictIO-iOS_Example-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PredictIO-iOS/Classes/PIOTripSegment.h
+++ b/PredictIO-iOS/Classes/PIOTripSegment.h
@@ -3,8 +3,8 @@
 //  PredictIOSDK
 //
 //  Created by Abdul Haseeb on 8/8/16.
-// Copyright (c) 2016 predict.io by ParkTAG GmbH. All rights reserved.
-//
+//  Copyright (c) 2016 predict.io by ParkTAG GmbH. All rights reserved.
+//  Version 3.0.1
 
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
@@ -52,6 +52,9 @@ typedef NS_ENUM(int, LogLevel)  {
 
 @interface PIOTripSegment : NSObject
 
+/** @brief Trip Segment UUID */
+@property (strong, readonly) NSString *UUID;
+
 /** @brief Location from where the user departed */
 @property (strong, readonly) CLLocation *departureLocation;
 
@@ -67,14 +70,11 @@ typedef NS_ENUM(int, LogLevel)  {
 /** @brief Predicted mode of transport */
 @property (assign, readonly) TransportationMode transportationMode;
 
-/** @brief Trip Segment UUID */
-@property (strong, readonly) NSString *UUID;
-
-- (id)initWithDepartureLocation:(CLLocation *)departureLocation
-                arrivalLocation:(CLLocation *)arrivalLocation
-                  departureTime:(NSDate *)departureTime
-                    arrivalTime:(NSDate *)arrivalTime
-             transportationMode:(TransportationMode)transportationMode
-                           UUID:(NSString *)UUID;
+- (id)initWithUUID:(NSString *)UUID
+ departureLocation:(CLLocation *)departureLocation
+   arrivalLocation:(CLLocation *)arrivalLocation
+     departureTime:(NSDate *)departureTime
+       arrivalTime:(NSDate *)arrivalTime
+transportationMode:(TransportationMode)transportationMode;
 
 @end

--- a/PredictIO-iOS/Classes/PodsDummy_PredictIO.m
+++ b/PredictIO-iOS/Classes/PodsDummy_PredictIO.m
@@ -3,7 +3,19 @@
 //  Pods
 //
 //  Created by Abdul Haseeb on 9/26/16.
-//
-//
+//  Copyright (c) 2016 predict.io by ParkTAG GmbH. All rights reserved.
+//  Version 3.0.1
 
 #import <Foundation/Foundation.h>
+
+/**
+ A bug exists in CocoaPods which causes header files to be missing in installed pods
+ whenever the pod is distributed as a static library and corresponding headers.
+ 
+ As such we include this empty implementation file to ensure that CocoaPods correctly
+ generates a target with the HEADER_SEARCH_PATHS property correctly set.
+ 
+ Some additional info can be found on the following issues:
+ - https://github.com/CocoaPods/CocoaPods/issues/3499
+ - https://github.com/CocoaPods/CocoaPods/issues/5357
+ */

--- a/PredictIO-iOS/Classes/PodsDummy_PredictIO.m
+++ b/PredictIO-iOS/Classes/PodsDummy_PredictIO.m
@@ -1,0 +1,9 @@
+//
+//  PodsDummy_PredictIO.m
+//  Pods
+//
+//  Created by Abdul Haseeb on 9/26/16.
+//
+//
+
+#import <Foundation/Foundation.h>

--- a/PredictIO-iOS/Classes/PredictIO.h
+++ b/PredictIO-iOS/Classes/PredictIO.h
@@ -4,7 +4,7 @@
 //
 //  Created by Zee on 28/02/2013.
 //  Copyright (c) 2016 predict.io by ParkTAG GmbH. All rights reserved.
-//  Version 3.0.0
+//  Version 3.0.1
 
 #import <Foundation/Foundation.h>
 #import "PIOTripSegment.h"
@@ -57,31 +57,36 @@
 
 /* This method is invoked when predict.io detects that the user is about to depart
  * from his location and is approaching to his vehicle
- * @param tripSegment: PIOTripSegment having departing event information
- * @discussion: At this point only following properties will be populated,
- *   departureLocation: The Location from where the user departed
- *   transportationMode:  Mode of transportation
+ * @param tripSegment: PIOTripSegment contains details about departing event
+ * @discussion: The following properties are populated currently:
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and arrival events
+ *  departureLocation: The Location from where the user departed
  */
 - (void)departing:(PIOTripSegment *)tripSegment;
 
 /* This method is invoked when predict.io detects that the user has just departed
  * from his location and have started a new trip
- * @param tripSegment: PIOTripSegment have departed event information
- * @discussion: At this point only following properties will be populated,
- *   departureLocation: The Location from where the user departed
- *   departureTime: Start time of the trip
- *   transportationMode: Mode of transportation
+ * @param tripSegment: PIOTripSegment contains details about departure event
+ * @discussion: The following properties are populated currently:
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and arrival events
+ *  departureLocation: The Location from where the user departed
+ *  departureTime: Time of departure
  */
 - (void)departed:(PIOTripSegment *)tripSegment;
 
 /* This method is invoked when predict.io is unable to validate the last departure event.
  * This can be due to invalid data received from sensors or the trip amplitude.
- * i.e. If the trip takes less than 5 minutes or the distance travelled is less than 3km
+ * i.e. If the trip takes less than 2 minutes or the distance travelled is less than 1km
  */
 - (void)departureCanceled;
 
 /* This method is invoked when predict.io detects transportation mode
- * @param: transportationMode: Mode of transportation
+ * @param tripSegment: PIOTripSegment contains details about user's transportation mode
+ * @discussion: The following properties are populated currently:
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and arrival events
+ *  departureLocation: The Location from where the user departed
+ *  departureTime: Time of departure
+ *  transportationMode: Mode of transportation
  */
 - (void)transportationMode:(PIOTripSegment *)tripSegment;
 
@@ -89,23 +94,25 @@
  * at his location and have ended a trip
  * Most of the time it is followed by a confirmed arrivedAtLocation event
  * If you need only confirmed arrival events, use arrivedAtLocation method (below) instead
- * @param tripSegment: PIOTripSegment have arrivalSuspected event information
- * @discussion: At this point only following properties will be populated,
+ * @param tripSegment: PIOTripSegment contains details about arrival suspected event
+ * @discussion: The following properties are populated currently:
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and arrival events
  *  departureLocation: The Location from where the user departed
  *  arrivalLocation: The Location where the user arrived and ended the trip
- *  departureTime: Start time of trip
- *  arrivalTime: Stop time of trip
+ *  departureTime: Time of departure
+ *  arrivalTime: Time of arrival
  *  transportationMode: Mode of transportation
  */
 - (void)arrivalSuspected:(PIOTripSegment *)tripSegment;
 
 /* This method is invoked when predict.io detects that the user has just arrived at destination
- * @param tripSegment: PIOTripSegment have arrived event information
- * @discussion: At this point only following properties will be populated,
+ * @param tripSegment: PIOTripSegment contains details about arrival event
+ * @discussion: The following properties are populated currently:
+ *  UUID: Unique ID for a trip segment, e.g. to link departure and arrival events
  *  departureLocation: The Location from where the user departed
  *  arrivalLocation: The Location where the user arrived and ended the trip
- *  departureTime: Start time of trip
- *  arrivalTime: Stop time of trip
+ *  departureTime: Time of departure
+ *  arrivalTime: Time of arrival
  *  transportationMode: Mode of transportation
  */
 - (void)arrived:(PIOTripSegment *)tripSegment;

--- a/PredictIO-iOS/PredictIO.modulemap
+++ b/PredictIO-iOS/PredictIO.modulemap
@@ -1,0 +1,6 @@
+framework module PredictIO {
+    umbrella header "PredictIO.h"
+
+    export *
+    module * { export * }
+}

--- a/PredictIO.podspec
+++ b/PredictIO.podspec
@@ -22,12 +22,15 @@ Pod::Spec.new do |s|
     s.source           = { :git => 'https://github.com/predict-io/PredictIO-iOS.git', :tag => s.version.to_s }
 
   #7
-    s.source_files = ['PredictIO-iOS/Classes/*.h']
-    s.preserve_paths = ['PredictIO-iOS/PredictIO.modulemap', 'LICENSE']
-    s.header_dir = 'PredictIO-iOS/Classes'
-    s.public_header_files = 'PredictIO-iOS/Classes/*.h'
+    s.public_header_files = 'PredictIO-iOS/**/*.h'
+    s.source_files = 'PredictIO-iOS/**/*.h', 'PredictIO-iOS/Classes/*.m'
+    s.preserve_paths = 'PredictIO-iOS/**/*.h'
     s.vendored_library = 'PredictIO-iOS/libPredictIO.a'
     s.frameworks = 'UIKit', 'CoreMotion', 'CoreLocation', 'CoreTelephony', 'AdSupport', 'AVFoundation', 'CoreBluetooth', 'SystemConfiguration', 'ExternalAccessory'
+    s.module_map = 'PredictIO-iOS/PredictIO.modulemap'
+    s.header_dir = 'PredictIO-iOS'
+    s.module_name = 'PredictIO'
+    s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 
   #8
     s.description = "You may use the parking updates to trigger events or notifications specific to your use case. The parking detection service stack leverages all available phone sensors. Sensor usage is extremely battery optimized. Incremental battery consumption does not exceed 10% in typical cases. Also we strongly suggest you ensure inclusion of LBS in your T&C and Privacy Policies. By using this API you explicitly agree to our license agreement, terms and conditions and privacy policy. If you are unsure about any item, please contact us at support@parktag.mobi."
@@ -35,4 +38,7 @@ Pod::Spec.new do |s|
     s.ios.module_map = 'PredictIO-iOS/PredictIO.modulemap'
     s.module_name = 'PredictIO'
     s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
+
+
+  
 end

--- a/PredictIO.podspec
+++ b/PredictIO.podspec
@@ -33,4 +33,5 @@ Pod::Spec.new do |s|
 
     s.ios.module_map = 'PredictIO-iOS/PredictIO.modulemap'
     s.module_name = 'PredictIO'
+    s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 end

--- a/PredictIO.podspec
+++ b/PredictIO.podspec
@@ -22,13 +22,15 @@ Pod::Spec.new do |s|
     s.source           = { :git => 'https://github.com/predict-io/PredictIO-iOS.git', :tag => s.version.to_s }
 
   #7
-    s.source_files = ['PredictIO-iOS/Classes/**/*.h','PredictIO-iOS/PredictIO.modulemap']
+    s.source_files = ['PredictIO-iOS/Classes/*.h', 'PredictIO-iOS/PredictIO.modulemap']
+    s.header_dir = 'PredictIO-iOS/Classes'
+    s.public_header_files = 'PredictIO-iOS/Classes/*.h'
     s.vendored_library = 'PredictIO-iOS/libPredictIO.a'
     s.frameworks = 'UIKit', 'CoreMotion', 'CoreLocation', 'CoreTelephony', 'AdSupport', 'AVFoundation', 'CoreBluetooth', 'SystemConfiguration', 'ExternalAccessory'
 
   #8
     s.description = "You may use the parking updates to trigger events or notifications specific to your use case. The parking detection service stack leverages all available phone sensors. Sensor usage is extremely battery optimized. Incremental battery consumption does not exceed 10% in typical cases. Also we strongly suggest you ensure inclusion of LBS in your T&C and Privacy Policies. By using this API you explicitly agree to our license agreement, terms and conditions and privacy policy. If you are unsure about any item, please contact us at support@parktag.mobi."
 
-    s.module_map = 'PredictIO-iOS/PredictIO.modulemap'
+    s.ios.module_map = 'PredictIO-iOS/PredictIO.modulemap'
     s.module_name = 'PredictIO'
 end

--- a/PredictIO.podspec
+++ b/PredictIO.podspec
@@ -22,7 +22,8 @@ Pod::Spec.new do |s|
     s.source           = { :git => 'https://github.com/predict-io/PredictIO-iOS.git', :tag => s.version.to_s }
 
   #7
-    s.source_files = ['PredictIO-iOS/Classes/*.h', 'PredictIO-iOS/PredictIO.modulemap']
+    s.source_files = ['PredictIO-iOS/Classes/*.h']
+    s.preserve_paths = ['PredictIO-iOS/PredictIO.modulemap', 'LICENSE']
     s.header_dir = 'PredictIO-iOS/Classes'
     s.public_header_files = 'PredictIO-iOS/Classes/*.h'
     s.vendored_library = 'PredictIO-iOS/libPredictIO.a'

--- a/PredictIO.podspec
+++ b/PredictIO.podspec
@@ -8,25 +8,27 @@ Pod::Spec.new do |s|
 
   # 2
     s.version = "3.0.1"
-  
+
   # 3
     s.license          = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
-  
+
   # 4
     s.author           = { "predict.io" => "developer@predict.io" }
 
   # 5
     s.homepage         = 'https://github.com/predict-io/PredictIO-iOS'
-  
+
   # 6
     s.source           = { :git => 'https://github.com/predict-io/PredictIO-iOS.git', :tag => s.version.to_s }
-  
+
   #7
-    s.source_files = 'PredictIO-iOS/Classes/**/*'
+    s.source_files = ['PredictIO-iOS/Classes/**/*.h','PredictIO-iOS/PredictIO.modulemap']
     s.vendored_library = 'PredictIO-iOS/libPredictIO.a'
     s.frameworks = 'UIKit', 'CoreMotion', 'CoreLocation', 'CoreTelephony', 'AdSupport', 'AVFoundation', 'CoreBluetooth', 'SystemConfiguration', 'ExternalAccessory'
-  
-  #8
-  s.description = "You may use the parking updates to trigger events or notifications specific to your use case. The parking detection service stack leverages all available phone sensors. Sensor usage is extremely battery optimized. Incremental battery consumption does not exceed 10% in typical cases. Also we strongly suggest you ensure inclusion of LBS in your T&C and Privacy Policies. By using this API you explicitly agree to our license agreement, terms and conditions and privacy policy. If you are unsure about any item, please contact us at support@parktag.mobi."
 
+  #8
+    s.description = "You may use the parking updates to trigger events or notifications specific to your use case. The parking detection service stack leverages all available phone sensors. Sensor usage is extremely battery optimized. Incremental battery consumption does not exceed 10% in typical cases. Also we strongly suggest you ensure inclusion of LBS in your T&C and Privacy Policies. By using this API you explicitly agree to our license agreement, terms and conditions and privacy policy. If you are unsure about any item, please contact us at support@parktag.mobi."
+
+    s.module_map = 'PredictIO-iOS/PredictIO.modulemap'
+    s.module_name = 'PredictIO'
 end


### PR DESCRIPTION
Creates a modulemap so that the Predict SDK in Swift projects can work as expected _without_ having to manually create a `BridgingHeader.h`.

After installing the CocoaPod in a Swift project you should now be able to `import PredictIO` without issue.
