### PR TITLE
Patch 1

### DIFF
--- a/PredictIO.podspec
+++ b/PredictIO.podspec
@@ -20,6 +20,10 @@ Pod::Spec.new do |s|
     # Default to latest Swift version
     s.vendored_frameworks = 'Frameworks/swift4.0/PredictIO.framework'
 
+    s.subspec 'Swift4.0' do |sp|
+      sp.vendored_frameworks = 'Frameworks/swift4.0/PredictIO.framework'
+    end
+    
     s.subspec 'Swift4.1' do |sp|
       sp.vendored_frameworks = 'Frameworks/swift4.1/PredictIO.framework'
     end


### PR DESCRIPTION
Please add 'Swift4.0' subspec. Or we will get 

```
[!] Unable to satisfy the following requirements:

- `PredictIO (from `git@github.com:predict-io/PredictIO-iOS.git`, branch `sdk5`)` required by `Podfile`

Specs satisfying the `PredictIO (from `git@github.com:predict-io/PredictIO-iOS.git`, branch `sdk5`)` dependency were found, but they required a higher minimum deployment target.

```

error.